### PR TITLE
Fix the "Failed prop type" warning generated by prop-types' checkProp…

### DIFF
--- a/src/LoadingOverlay.js
+++ b/src/LoadingOverlay.js
@@ -115,10 +115,10 @@ LoadingOverlayWrapper.propTypes = {
   spinner: PropTypes.oneOfType([ PropTypes.bool, PropTypes.node ]),
   text: PropTypes.node,
   styles: PropTypes.shape({
-    content: PropTypes.function,
-    overlay: PropTypes.function,
-    spinner: PropTypes.function,
-    wrapper: PropTypes.function
+    content: PropTypes.func,
+    overlay: PropTypes.func,
+    spinner: PropTypes.func,
+    wrapper: PropTypes.func
   })
 }
 


### PR DESCRIPTION
…Types

Warning:
Failed prop type: LoadingOverlayWrapper: prop type 'styles.content' is invalid; it must be a function, usually from the 'prop-types' package, but received 'undefined'